### PR TITLE
Fix syntax issue and prevent re-application of hibernate

### DIFF
--- a/manifests/global/hibernation.pp
+++ b/manifests/global/hibernation.pp
@@ -32,7 +32,7 @@ define windows_power::global::hibernation(
 
   exec { 'update hibernate status':
     command  => "powercfg -hibernate ${status}",
-    unless => 'if($(Get-ItemPropertyValue HKLM:\SYSTEM\CurrentControlSet\Control\Power -name HibernateEnabled) -eq 0) {exit 0} else {exit 1}',
+    unless   => 'if($(Get-ItemPropertyValue HKLM:\SYSTEM\CurrentControlSet\Control\Power -name HibernateEnabled) -eq 0) {exit 0} else {exit 1}',
     provider => powershell,
   }
 }

--- a/manifests/global/hibernation.pp
+++ b/manifests/global/hibernation.pp
@@ -33,5 +33,6 @@ define windows_power::global::hibernation(
   exec { 'update hibernate status':
     command  => "${windows_power::params::powercfg} -hibernate ${status}",
     provider => windows,
+    unless => 'if($(Get-ItemPropertyValue HKLM:\SYSTEM\CurrentControlSet\Control\Power -name HibernateEnabled) -eq 0) {exit 0} else {exit 1}',
   }
 }

--- a/manifests/global/hibernation.pp
+++ b/manifests/global/hibernation.pp
@@ -31,8 +31,8 @@ define windows_power::global::hibernation(
   validate_re($status,'^(on|off)$','The status argument is not valid for hibernate')
 
   exec { 'update hibernate status':
-    command  => "${windows_power::params::powercfg} -hibernate ${status}",
-    provider => windows,
+    command  => "powercfg -hibernate ${status}",
     unless => 'if($(Get-ItemPropertyValue HKLM:\SYSTEM\CurrentControlSet\Control\Power -name HibernateEnabled) -eq 0) {exit 0} else {exit 1}',
+    provider => powershell,
   }
 }

--- a/manifests/schemes/settings.pp
+++ b/manifests/schemes/settings.pp
@@ -49,6 +49,6 @@ define windows_power::schemes::settings(
     command   => "& ${windows_power::params::powercfg} /change ${setting} ${value}",
     provider  => powershell,
     logoutput => true,
-    unless    => "${windows_power::params::nasty_ps} \$items.contains(${scheme_name})",
+    unless    => "${windows_power::params::nasty_ps} \$items.contains(\"${scheme_name}\")",
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
I experienced syntax errors when using windows_power::schemes::settings resources. The errors were based on the fact, that the unless check for this resource tried to access a variable named like the schema. This is since the name of the schema was not quoted in the command.

Furthermore the exec command in the  windows_power::global::hibernation resource was always executed, which is not very nice when looking at catalog applications in foreman.

#### This Pull Request (PR) fixes the following issues
The above mentioned issues are fixed by these commits.