### PR TITLE
drop stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
-    stdlib:  'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     powershell:  'https://github.com/puppetlabs/puppetlabs-powershell.git'
     pwshlib: 'https://github.com/puppetlabs/ruby-pwsh.git'
     win_facts:  'https://github.com/liamjbennett/puppet-win_facts.git'

--- a/manifests/devices/override.pp
+++ b/manifests/devices/override.pp
@@ -6,11 +6,6 @@
 #
 # This definition manages a Power Request override for a particular Process, Service, or Driver.
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*type*]
@@ -27,13 +22,10 @@
 #    }
 #
 define windows_power::devices::override (
-  $type,
-  $request,
+  Enum['PROCESS', 'SERVICE', 'DRIVER'] $type,
+  Enum['Display', 'System', 'Awaymode'] $request,
 ) {
   include windows_power::params
-
-  validate_re($type,'^(PROCESS|SERVICE|DRIVER)$','The caller type argument does not match: PROCESS, SERVICE or DRIVER')
-  validate_re($request,'^(Display|System|Awaymode)$','The request type argument does not match: Display, System or Awaymode')
 
   case $facts['operatingsystemversion'] {
     'Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2': {

--- a/manifests/devices/wake.pp
+++ b/manifests/devices/wake.pp
@@ -6,11 +6,6 @@
 #
 # This definition enables/disables the device to wake the computer from a sleep state
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*device*]
@@ -27,13 +22,10 @@
 #    }
 #
 define windows_power::devices::wake (
-  $device,
-  $ensure = 'enable',
+  String[1] $device,
+  Enum['enable', 'disable'] $ensure = 'enable',
 ) {
   include windows_power::params
-
-  validate_string($device)
-  validate_re($ensure,'^(enable|disable)$','The ensure argument does not match: enable or disable')
 
   exec { "device ${device} ${ensure} wake":
     command  => "${windows_power::params::powercfg} /device${ensure}wake \"${device}\"",

--- a/manifests/global/battery.pp
+++ b/manifests/global/battery.pp
@@ -6,18 +6,13 @@
 #
 # This definition configured the battery alarm
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*setting*]
 # Battery alarm setting to configure
 #
 # [*status*]
-# Setting configuration (on/off) or percentage (in the case of the level setting)
+# Setting configuration
 #
 # [*criticality*]
 # The level of battery criticality at which to provide an alarm. LOW or HIGH.
@@ -30,15 +25,19 @@
 #    }
 #
 define windows_power::global::battery (
-  $setting,
-  $status,
-  $criticality = 'LOW',
+  String[1] $setting,
+  String[1] $status,
+  Enum['LOW', 'HIGH'] $criticality = 'LOW',
 ) {
   include windows_power::params
 
-  validate_re($setting,keys($windows_power::params::batteryalarm_settings),'The setting argument does not match a valid batteryalarm setting')
-  validate_re($status,$windows_power::params::batteryalarm_settings[$setting],"The status argument is not valid for ${setting}")
-  validate_re($criticality,'^(LOW|HIGH)$','The status argument does not match: LOW or HIGH')
+  if ! ($setting in $windows_power::params::batteryalarm_settings) {
+    fail('The setting argument does not match a valid batteryalarm setting')
+  }
+
+  if $status !~ $windows_power::params::batteryalarm_settings[$setting] {
+    fail("The status argument is not valid for ${setting}")
+  }
 
   case $facts['operatingsystemversion'] {
     'Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2': {

--- a/manifests/global/flags.pp
+++ b/manifests/global/flags.pp
@@ -6,11 +6,6 @@
 #
 # This definition configured the battery alarm
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*setting*]
@@ -27,13 +22,14 @@
 #    }
 #
 define windows_power::global::flags (
-  $setting,
-  $status,
+  String[1] $setting,
+  Enum['on', 'off'] $status,
 ) {
   include windows_power::params
 
-  validate_re($setting,$windows_power::params::globalpower_flags,'The setting argument does not match a valid globalpower flag')
-  validate_re($status,'^(on|off)$',"The status argument is not valid for ${setting}")
+  if ! ($setting in $windows_power::params::globalpower_flags) {
+    fail('The setting argument does not match a valid globalpower flag')
+  }
 
   case $facts['operatingsystemversion'] {
     'Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2': {

--- a/manifests/global/hibernation.pp
+++ b/manifests/global/hibernation.pp
@@ -6,11 +6,6 @@
 #
 # This definition configures hibernation on a box
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*status*]
@@ -23,11 +18,9 @@
 #    }
 #
 define windows_power::global::hibernation (
-  $status,
+  Enum['on', 'off'] $status,
 ) {
   include windows_power::params
-
-  validate_re($status,'^(on|off)$','The status argument is not valid for hibernate')
 
   exec { 'update hibernate status':
     command  => "${windows_power::params::powercfg} -hibernate ${status}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,11 +6,6 @@
 #
 # Module to mananage the configuration of a machines autoupdate settings
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # === Examples

--- a/manifests/schemes/scheme.pp
+++ b/manifests/schemes/scheme.pp
@@ -6,11 +6,6 @@
 #
 # This definition configures a specific power scheme
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*scheme_name*]
@@ -39,29 +34,14 @@
 #    }
 #
 define windows_power::schemes::scheme (
-  $scheme_name,
-  $scheme_guid,
-  $template_scheme = '',
-  $activation      = '',
-  $ensure          = 'present',
+  String[1] $scheme_name,
+  Pattern[/\A[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}\z/] $scheme_guid,
+  String[1] $template_scheme,
+  Enum['active', 'inactive'] $activation,
+  Enum['present', 'absent'] $ensure = 'present',
 ) {
   include windows_power::params
 
-  validate_string($scheme_name)
-  validate_re($scheme_guid,'^[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}$','The scheme guid provided is not formatted correctly')
-  validate_re($ensure,'^(present|absent)$','The ensure argument is not set to present or absent')
-
-  case $facts['operatingsystemversion'] {
-    'Windows Vista','Windows 7','Windows 8','Windows Server 2008','Windows Server 2008 R2','Windows Server 2012': {
-      if $ensure == 'present' {
-        validate_string($template_scheme)
-        validate_re($activation,'^(active|inactive)$','The activation argument is not set to active or inactive')
-      }
-    }
-    default: {}
-  }
-
-  $template_guid = $windows_power::params::template_schemes[$template_scheme]
   $scheme_check = "${windows_power::params::nasty_ps} \$items.contains('${scheme_name}')"
 
   if $ensure == 'present' {

--- a/manifests/schemes/settings.pp
+++ b/manifests/schemes/settings.pp
@@ -6,11 +6,6 @@
 #
 # This definition configures settings for a specific scheme
 #
-# === Requirements/Dependencies
-#
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
-# order to validate much of the the provided configuration.
-#
 # === Parameters
 #
 # [*scheme_name*]
@@ -31,18 +26,21 @@
 #    }
 #
 define windows_power::schemes::settings (
-  $scheme_name,
-  $setting,
-  $value,
+  String[1] $scheme_name,
+  String[1] $setting,
+  String[1] $value,
 ) {
   include windows_power::params
 
-  validate_string($scheme_name)
-
   $settings_regex = join(keys($windows_power::params::scheme_settings), '|')
-  validate_re($setting, "^(${settings_regex})$", 'The setting argument does not match a valid scheme setting')
 
-  validate_re($value, $windows_power::params::scheme_settings[$setting], "The value provided is not appropriate for the ${setting} setting")
+  if $setting !~ "^${settings_regex}$" {
+    fail('The setting argument does not match a valid scheme setting')
+  }
+
+  if $value !~ $windows_power::params::scheme_settings[$setting] {
+    fail("The value provided is not appropriate for the ${setting} setting")
+  }
 
   exec { "modify ${setting} setting for ${scheme_name}":
     command   => "& ${windows_power::params::powercfg} /change ${setting} ${value}",

--- a/metadata.json
+++ b/metadata.json
@@ -20,10 +20,6 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 9.0.0"
-    },
-    {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 1.0.5 < 3.0.0"
     },

--- a/spec/defines/devices/override_spec.rb
+++ b/spec/defines/devices/override_spec.rb
@@ -3,32 +3,6 @@
 require 'spec_helper'
 
 describe 'windows_power::devices::override', type: :define do
-  describe 'installing with invalid type' do
-    let(:title) { 'wmplayer.exe' }
-    let(:params) do
-      { type: 'xxx', request: 'Display' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('request override for wmplayer.exe')
-      end.to raise_error(Puppet::Error, %r{The caller type argument does not match: PROCESS, SERVICE or DRIVER})
-    end
-  end
-
-  describe 'installing with invalid request' do
-    let(:title) { 'wmplayer.exe' }
-    let(:params) do
-      { type: 'PROCESS', request: 'xxx' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('request override for wmplayer.exe')
-      end.to raise_error(Puppet::Error, %r{The request type argument does not match: Display, System or Awaymode})
-    end
-  end
-
   ['Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2'].each do |os|
     describe "requestsoverride not supported on #{os}" do
       let(:title) { 'wmplayer.exe' }

--- a/spec/defines/devices/wake_spec.rb
+++ b/spec/defines/devices/wake_spec.rb
@@ -16,19 +16,6 @@ describe 'windows_power::devices::wake', type: :define do
     end
   end
 
-  describe 'enabling wake with invalid ensure' do
-    let(:title) { 'network-device' }
-    let(:params) do
-      { device: 'network-device', ensure: 'x' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('device network-device enable wake')
-      end.to raise_error(Puppet::Error, %r{The ensure argument does not match: enable or disable})
-    end
-  end
-
   describe 'enabling wake' do
     let(:title) { 'VMBus Enumerator (001)' }
     let(:params) do

--- a/spec/defines/global/battery_spec.rb
+++ b/spec/defines/global/battery_spec.rb
@@ -29,19 +29,6 @@ describe 'windows_power::global::battery', type: :define do
     end
   end
 
-  describe 'installing with invalid criticality' do
-    let(:title) { 'sound off' }
-    let(:params) do
-      { setting: 'sound', status: 'on', criticality: 'xxx' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('set batteryalarm sound')
-      end.to raise_error(Puppet::Error, %r{The status argument does not match: LOW or HIGH})
-    end
-  end
-
   ['Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2'].each do |os|
     describe 'installing setting sound' do
       let(:title) { 'sound' }

--- a/spec/defines/global/flags_spec.rb
+++ b/spec/defines/global/flags_spec.rb
@@ -16,19 +16,6 @@ describe 'windows_power::global::flags', type: :define do
     end
   end
 
-  describe 'installing with invalid status' do
-    let(:title) { 'BatteryIcon' }
-    let(:params) do
-      { setting: 'BatteryIcon', status: 'xxx' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('set globalpowerflag BatteryIcon')
-      end.to raise_error(Puppet::Error, %r{The status argument is not valid for BatteryIcon})
-    end
-  end
-
   ['Windows XP', 'Windows Server 2003', 'Windows Server 2003 R2'].each do |os|
     describe 'installing setting BatteryIcon' do
       let(:title) { 'BatteryIcon' }

--- a/spec/defines/global/hibernation_spec.rb
+++ b/spec/defines/global/hibernation_spec.rb
@@ -3,19 +3,6 @@
 require 'spec_helper'
 
 describe 'windows_power::global::hibernation', type: :define do
-  describe 'updating with invalid status' do
-    let(:title) { 'hibernate on' }
-    let(:params) do
-      { status: 'xxx' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('update hibernate status')
-      end.to raise_error(Puppet::Error, %r{The status argument is not valid for hibernate})
-    end
-  end
-
   describe 'updating hibernate on' do
     let(:title) { 'hibernate on' }
     let(:params) do

--- a/spec/defines/schemes/scheme_spec.rb
+++ b/spec/defines/schemes/scheme_spec.rb
@@ -16,32 +16,6 @@ describe 'windows_power::schemes::scheme', type: :define do
     end
   end
 
-  describe 'installing with invalid scheme guid' do
-    let(:title) { 'create new scheme test' }
-    let(:params) do
-      { scheme_name: 'test', scheme_guid: 'x' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('create power scheme test')
-      end.to raise_error(Puppet::Error, %r{The scheme guid provided is not formatted correctly})
-    end
-  end
-
-  describe 'installing with invalid ensure' do
-    let(:title) { 'create new scheme test' }
-    let(:params) do
-      { scheme_name: 'test', scheme_guid: '381b4222-f694-41f0-9685-ff5bb260df2e', ensure: 'fubar' }
-    end
-
-    it do
-      expect do
-        is_expected.to contain_exec('create power scheme test')
-      end.to raise_error(Puppet::Error, %r{The ensure argument is not set to present or absent})
-    end
-  end
-
   ['Windows Vista', 'Windows 7', 'Windows 8', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2012'].each do |os|
     describe 'installing with invalid template scheme name' do
       let(:title) { 'create new scheme test' }
@@ -56,22 +30,6 @@ describe 'windows_power::schemes::scheme', type: :define do
         expect do
           is_expected.to contain_exec('create power scheme test')
         end.to raise_error(Puppet::Error)
-      end
-    end
-
-    describe 'installing with invalid activation' do
-      let(:title) { 'create new scheme test' }
-      let(:facts) do
-        { operatingsystemversion: os }
-      end
-      let(:params) do
-        { scheme_name: 'test', scheme_guid: '381b4222-f694-41f0-9685-ff5bb260df2e', activation: 'fubar' }
-      end
-
-      it do
-        expect do
-          is_expected.to contain_exec('create power scheme test')
-        end.to raise_error(Puppet::Error, %r{The activation argument is not set to active or inactive})
       end
     end
   end


### PR DESCRIPTION
This drops the dependency to puppetlabs/stdlib from the manifests:
- legacy `validate_` methods are replaced by DSL
- inline docs informing about the requirement are removed
- all kind of previously existing functionality is kept the way it was besides some tiny improvements (big rework will follow soon)