### PR TITLE
#57 fix corrective changes + duplicate/rename scheme in one puppet run

### DIFF
--- a/lib/facter/hibernation_enabled.rb
+++ b/lib/facter/hibernation_enabled.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Facter.add(:hibernation_enabled) do
+  confine kernel: 'windows'
+
+  # This facts reads the registry value of
+  # "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Power\HibernateEnabled"
+  # to check if hibernation is active (1 = hibernation on, everything else = hibernation off)
+
+  setcode do
+    begin
+      key = 'SYSTEM\\CurrentControlSet\\Control\\Power'
+      value = nil
+      Win32::Registry::HKEY_LOCAL_MACHINE.open(key, Win32::Registry::KEY_READ) do |reg|
+        value = reg['HibernateEnabled']
+      end
+      value == 1
+    rescue Win32::Registry::Error
+      false
+    end
+  end
+end

--- a/lib/facter/hibernation_enabled.rb
+++ b/lib/facter/hibernation_enabled.rb
@@ -8,15 +8,13 @@ Facter.add(:hibernation_enabled) do
   # to check if hibernation is active (1 = hibernation on, everything else = hibernation off)
 
   setcode do
-    begin
-      key = 'SYSTEM\\CurrentControlSet\\Control\\Power'
-      value = nil
-      Win32::Registry::HKEY_LOCAL_MACHINE.open(key, Win32::Registry::KEY_READ) do |reg|
-        value = reg['HibernateEnabled']
-      end
-      value == 1
-    rescue Win32::Registry::Error
-      false
+    key = 'SYSTEM\\CurrentControlSet\\Control\\Power'
+    value = nil
+    Win32::Registry::HKEY_LOCAL_MACHINE.open(key, Win32::Registry::KEY_READ) do |reg|
+      value = reg['HibernateEnabled']
     end
+    value == 1
+  rescue Win32::Registry::Error
+    false
   end
 end

--- a/lib/facter/power_settings.rb
+++ b/lib/facter/power_settings.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/RegexpLiteral
-
 Facter.add(:power_settings) do
   confine kernel: 'windows'
 
@@ -13,14 +11,14 @@ Facter.add(:power_settings) do
     data_blocks = output.split(/\n\n/)
 
     result = {
-      'monitor-timeout-ac'    => 0,
-      'monitor-timeout-dc'    => 0,
-      'disk-timeout-ac'       => 0,
-      'disk-timeout-dc'       => 0,
-      'standby-timeout-ac'    => 0,
-      'standby-timeout-dc'    => 0,
-      'hibernate-timeout-ac'  => 0,
-      'hibernate-timeout-dc'  => 0,
+      'monitor-timeout-ac' => 0,
+      'monitor-timeout-dc' => 0,
+      'disk-timeout-ac' => 0,
+      'disk-timeout-dc' => 0,
+      'standby-timeout-ac' => 0,
+      'standby-timeout-dc' => 0,
+      'hibernate-timeout-ac' => 0,
+      'hibernate-timeout-dc' => 0,
     }
 
     hex = '[a-f0-9]'
@@ -31,7 +29,7 @@ Facter.add(:power_settings) do
       guid = ''
       lines = block.lines(chomp: true)
       lines.each do |line|
-        if line.match /(#{guid_re})/
+        if line.match(/(#{guid_re})/)
           # Get the last GUID in the block
           guid = $1
         end
@@ -69,5 +67,3 @@ Facter.add(:power_settings) do
     result
   end
 end
-
-# rubocop:enable Style/RegexpLiteral

--- a/lib/facter/power_settings.rb
+++ b/lib/facter/power_settings.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/RegexpLiteral
+
+Facter.add(:power_settings) do
+  confine kernel: 'windows'
+
+  # This fact runs "powercfg /query" to get the settings
+  # for the currently active power scheme.
+
+  setcode do
+    output = Facter::Core::Execution.execute('powercfg /query')
+    data_blocks = output.split(/\n\n/)
+
+    result = {
+      'monitor-timeout-ac'    => 0,
+      'monitor-timeout-dc'    => 0,
+      'disk-timeout-ac'       => 0,
+      'disk-timeout-dc'       => 0,
+      'standby-timeout-ac'    => 0,
+      'standby-timeout-dc'    => 0,
+      'hibernate-timeout-ac'  => 0,
+      'hibernate-timeout-dc'  => 0,
+    }
+
+    hex = '[a-f0-9]'
+    guid_re = "#{hex}{8}-#{hex}{4}-#{hex}{4}-#{hex}{4}-#{hex}{12}"
+
+    # Split the output of "powercfg /query" into blocks (empty line = new block begins):
+    data_blocks.each do |block|
+      guid = ''
+      lines = block.lines(chomp: true)
+      lines.each do |line|
+        if line.match /(#{guid_re})/
+          # Get the last GUID in the block
+          guid = $1
+        end
+      end
+      # Get the hex values of the last two lines in a block.
+      # Example output:
+      # Index der aktuellen Wechselstromeinstellung: 0x00000002
+      # Index der aktuellen Gleichstromeinstellung: 0x00000002
+      ac = lines[-2].split(': ')[1].to_i(0) # AC in seconds
+      dc = lines[-1].split(': ')[1].to_i(0) # DC in seconds
+
+      # "powercfg /aliases" displays a list of aliases and their corresponding GUIDs:
+      # 0012ee47-9041-4b5d-9b77-535fba8b1442  SUB_DISK
+      # 6738e2c4-e8a5-4a42-b16a-e040e769756e    DISKIDLE      -> disk-timeout-ac/-dc
+      # 238c9fa8-0aad-41ed-83f4-97be242c8f20  SUB_SLEEP
+      # 9d7815a6-7ee4-497e-8888-515a05f02364    HIBERNATEIDLE -> hibernate-timeout-ac/-dc
+      # 29f6c1db-86da-48c5-9fdb-f2b67b1f44da    STANDBYIDLE   -> standby-timeout-ac/-dc
+      # 7516b95f-f776-4464-8c53-06167f40cc99  SUB_VIDEO
+      # 3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e    VIDEOIDLE     -> monitor-timeout-ac/-dc
+      case guid
+      when '3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e' # VIDEOIDLE
+        result['monitor-timeout-ac'] = ac
+        result['monitor-timeout-dc'] = dc
+      when '6738e2c4-e8a5-4a42-b16a-e040e769756e' # DISKIDLE
+        result['disk-timeout-ac'] = ac
+        result['disk-timeout-dc'] = dc
+      when '29f6c1db-86da-48c5-9fdb-f2b67b1f44da' # STANDBYIDLE
+        result['standby-timeout-ac'] = ac
+        result['standby-timeout-dc'] = dc
+      when '9d7815a6-7ee4-497e-8888-515a05f02364' # HIBERNATEIDLE
+        result['hibernate-timeout-ac'] = ac
+        result['hibernate-timeout-dc'] = dc
+      end
+    end
+    result
+  end
+end
+
+# rubocop:enable Style/RegexpLiteral

--- a/lib/facter/power_settings.rb
+++ b/lib/facter/power_settings.rb
@@ -8,7 +8,7 @@ Facter.add(:power_settings) do
 
   setcode do
     output = Facter::Core::Execution.execute('powercfg /query')
-    data_blocks = output.split(/\n\n/)
+    data_blocks = output.split(%r{\n\n})
 
     result = {
       'monitor-timeout-ac' => 0,
@@ -29,9 +29,9 @@ Facter.add(:power_settings) do
       guid = ''
       lines = block.lines(chomp: true)
       lines.each do |line|
-        if line.match(/(#{guid_re})/)
+        if line.match(%r{(#{guid_re})})
           # Get the last GUID in the block
-          guid = $1
+          guid = Regexp.last_match(1)
         end
       end
       # Get the hex values of the last two lines in a block.

--- a/manifests/hibernate.pp
+++ b/manifests/hibernate.pp
@@ -31,10 +31,12 @@ class windows_power::hibernate (
   Optional[Enum['reduced', 'full']] $hiberfile_type = undef,
 ) {
   if $enable {
-    exec { 'enable_hibernate':
-      provider => windows,
-      path     => $facts['os']['windows']['system32'],
-      command  => 'powercfg /hibernate on',
+    unless $facts['hibernation_enabled'] {
+      exec { 'enable_hibernate':
+        provider => windows,
+        path     => $facts['os']['windows']['system32'],
+        command  => 'powercfg /hibernate on',
+      }
     }
 
     if $hiberfile_size !~ Undef {
@@ -54,10 +56,12 @@ class windows_power::hibernate (
     }
   }
   else {
-    exec { 'disable_hibernate':
-      provider => windows,
-      path     => $facts['os']['windows']['system32'],
-      command  => 'powercfg /hibernate off',
+    if $facts['hibernation_enabled'] {
+      exec { 'disable_hibernate':
+        provider => windows,
+        path     => $facts['os']['windows']['system32'],
+        command  => 'powercfg /hibernate off',
+      }
     }
   }
 }

--- a/manifests/scheme.pp
+++ b/manifests/scheme.pp
@@ -75,35 +75,43 @@ class windows_power::scheme (
   }
 
   if ($guid in $facts['power_schemes']) and !($facts['power_schemes'][$guid]['active']) {
-    exec { 'activate_power_scheme':
+    exec { 'activate_existing_power_scheme':
       provider => windows,
       path     => $facts['os']['windows']['system32'],
       command  => "powercfg /setactive ${guid}",
     }
   }
   elsif !($guid in $facts['power_schemes']) {
-    exec { 'activate_power_scheme':
-      provider => powershell,
-      command  => "& powercfg /setactive ${guid}",
-      onlyif   => "([System.Collections.ArrayList]@(powercfg /l | % { if (\$_ -match '^.*?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*\$') {\$matches[1]} })).contains('${guid}')",
+    # active the newly duplicated scheme
+    exec { 'activate_duplicated_power_scheme':
+      provider    => windows,
+      path        => $facts['os']['windows']['system32'],
+      command     => "powercfg /setactive ${guid}",
+      subscribe   => Exec['duplicate_existing_power_scheme'],
+      refreshonly => true,
     }
   }
 
   if $label !~ Undef {
+    $rename_command = $description ? {
+      undef   => "powercfg /changename ${guid} \"${label}\"" , # with description
+      default => "powercfg /changename ${guid} \"${label}\" \"${description}\"", # without description
+    }
     if ($guid in $facts['power_schemes']) and ($facts['power_schemes'][$guid]['name'] != $label) {
-      if $description !~ Undef {
-        exec { 'rename_power_scheme':
-          provider => windows,
-          path     => $facts['os']['windows']['system32'],
-          command  => "powercfg /changename ${guid} \"${label}\" \"${description}\"",
-        }
+      exec { 'rename_power_scheme':
+        provider => windows,
+        path     => $facts['os']['windows']['system32'],
+        command  => $rename_command,
       }
-      else {
-        exec { 'rename_power_scheme':
-          provider => windows,
-          path     => $facts['os']['windows']['system32'],
-          command  => "powercfg /changename ${guid} \"${label}\"",
-        }
+    }
+    elsif !($guid in $facts['power_schemes']) {
+      # rename the newly duplicated and activated scheme in one puppet run
+      exec { 'rename_power_scheme':
+        provider    => windows,
+        path        => $facts['os']['windows']['system32'],
+        command     => $rename_command,
+        subscribe   => Exec['activate_duplicated_power_scheme'],
+        refreshonly => true,
       }
     }
   }
@@ -111,10 +119,13 @@ class windows_power::scheme (
   if ($guid in $facts['power_schemes']) and $facts['power_schemes'][$guid]['active'] {
     if $settings !~ Undef {
       each($settings) |$key, $value| {
-        exec { "set_power_scheme_setting_${key}":
-          provider => windows,
-          path     => $facts['os']['windows']['system32'],
-          command  => "powercfg /change ${key} ${value}",
+        # facts power_settings is the value in seconds
+        if $facts['power_settings'][$key] != $value * 60 {
+          exec { "set_power_scheme_setting_${key}":
+            provider => windows,
+            path     => $facts['os']['windows']['system32'],
+            command  => "powercfg /change ${key} ${value}",
+          }
         }
       }
     }

--- a/manifests/scheme.pp
+++ b/manifests/scheme.pp
@@ -65,11 +65,20 @@ class windows_power::scheme (
   ], Integer[0], 1, 8]] $settings = undef,
 ) {
   if $template !~ Undef {
-    if !($guid in $facts['power_schemes']) and ($template in $facts['power_schemes']) {
-      exec { 'duplicate_existing_power_scheme':
-        provider => windows,
-        path     => $facts['os']['windows']['system32'],
-        command  => "powercfg /duplicatescheme ${template} ${guid}",
+    if !($guid in $facts['power_schemes']) {
+      if $template in $facts['power_schemes'] {
+        exec { 'duplicate_existing_power_scheme':
+          provider => windows,
+          path     => $facts['os']['windows']['system32'],
+          command  => "powercfg /duplicatescheme ${template} ${guid}",
+        }
+        exec { 'activate_duplicated_power_scheme':
+          provider => windows,
+          path     => $facts['os']['windows']['system32'],
+          command  => "powercfg /setactive ${guid}",
+        }
+      } else {
+        fail("The GUID of the template ${$template} does not exist!")
       }
     }
   }
@@ -79,16 +88,6 @@ class windows_power::scheme (
       provider => windows,
       path     => $facts['os']['windows']['system32'],
       command  => "powercfg /setactive ${guid}",
-    }
-  }
-  elsif !($guid in $facts['power_schemes']) {
-    # active the newly duplicated scheme
-    exec { 'activate_duplicated_power_scheme':
-      provider    => windows,
-      path        => $facts['os']['windows']['system32'],
-      command     => "powercfg /setactive ${guid}",
-      subscribe   => Exec['duplicate_existing_power_scheme'],
-      refreshonly => true,
     }
   }
 

--- a/manifests/scheme.pp
+++ b/manifests/scheme.pp
@@ -77,8 +77,6 @@ class windows_power::scheme (
           path     => $facts['os']['windows']['system32'],
           command  => "powercfg /setactive ${guid}",
         }
-      } else {
-        fail("The GUID of the template ${$template} does not exist!")
       }
     }
   }

--- a/spec/classes/hibernate_spec.rb
+++ b/spec/classes/hibernate_spec.rb
@@ -10,7 +10,7 @@ describe 'windows_power::hibernate' do
           system32: 'C:\WINDOWS\system32'
         }
       },
-      hibernation_enabled: false
+      hibernation_enabled: true
     }
   end
 
@@ -25,6 +25,17 @@ describe 'windows_power::hibernate' do
     it { is_expected.to contain_class('windows_power::hibernate') }
 
     it { is_expected.to contain_exec('disable_hibernate') }
+  end
+
+  let(:facts) do
+    {
+      os: {
+        windows: {
+          system32: 'C:\WINDOWS\system32'
+        }
+      },
+      hibernation_enabled: false
+    }
   end
 
   context 'enable hibernation with default settings' do

--- a/spec/classes/hibernate_spec.rb
+++ b/spec/classes/hibernate_spec.rb
@@ -3,18 +3,18 @@
 require 'spec_helper'
 
 describe 'windows_power::hibernate' do
-  let(:facts) do
-    {
-      os: {
-        windows: {
-          system32: 'C:\WINDOWS\system32'
-        }
-      },
-      hibernation_enabled: true
-    }
-  end
-
   context 'disable hibernation system wide' do
+    let(:facts) do
+      {
+        os: {
+          windows: {
+            system32: 'C:\WINDOWS\system32'
+          }
+        },
+        hibernation_enabled: true
+      }
+    end
+
     let(:params) do
       {
         enable: false
@@ -27,18 +27,18 @@ describe 'windows_power::hibernate' do
     it { is_expected.to contain_exec('disable_hibernate') }
   end
 
-  let(:facts) do
-    {
-      os: {
-        windows: {
-          system32: 'C:\WINDOWS\system32'
-        }
-      },
-      hibernation_enabled: false
-    }
-  end
-
   context 'enable hibernation with default settings' do
+    let(:facts) do
+      {
+        os: {
+          windows: {
+            system32: 'C:\WINDOWS\system32'
+          }
+        },
+        hibernation_enabled: false
+      }
+    end
+
     let(:params) do
       {
         enable: true
@@ -54,6 +54,17 @@ describe 'windows_power::hibernate' do
   end
 
   context 'enable and configure hibernation' do
+    let(:facts) do
+      {
+        os: {
+          windows: {
+            system32: 'C:\WINDOWS\system32'
+          }
+        },
+        hibernation_enabled: false
+      }
+    end
+
     let(:params) do
       {
         enable: true,

--- a/spec/classes/hibernate_spec.rb
+++ b/spec/classes/hibernate_spec.rb
@@ -9,7 +9,8 @@ describe 'windows_power::hibernate' do
         windows: {
           system32: 'C:\WINDOWS\system32'
         }
-      }
+      },
+      hibernation_enabled: false
     }
   end
 

--- a/spec/classes/scheme_spec.rb
+++ b/spec/classes/scheme_spec.rb
@@ -218,31 +218,33 @@ describe 'windows_power::scheme' do
     end
   end
 
-  context 'duplicate non-existing power scheme' do
-    let(:facts) do
-      super().merge(
-        {
-          power_schemes: {
-            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-          }
-        }
-      )
-    end
+  # You cannot copy an non-existing scheme!
+  #
+  # context 'duplicate non-existing power scheme' do
+  #   let(:facts) do
+  #     super().merge(
+  #       {
+  #         power_schemes: {
+  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+  #         }
+  #       }
+  #     )
+  #   end
 
-    let(:params) do
-      {
-        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
-        template: '7c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-      }
-    end
+  #   let(:params) do
+  #     {
+  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
+  #       template: '7c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+  #     }
+  #   end
 
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('windows_power::scheme') }
+  #   it { is_expected.to compile.with_all_deps }
+  #   it { is_expected.to contain_class('windows_power::scheme') }
 
-    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
 
-    it { is_expected.not_to contain_exec('rename_power_scheme') }
-  end
+  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
+  # end
 
   context 'configure existing power scheme' do
     context 'which is active already' do
@@ -318,35 +320,37 @@ describe 'windows_power::scheme' do
     end
   end
 
-  context 'configure non-existing power scheme' do
-    let(:facts) do
-      super().merge(
-        {
-          power_schemes: {
-            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-          }
-        }
-      )
-    end
+  # You cannot copy an non-existing scheme!
+  #
+  # context 'configure non-existing power scheme' do
+  #   let(:facts) do
+  #     super().merge(
+  #       {
+  #         power_schemes: {
+  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+  #         }
+  #       }
+  #     )
+  #   end
 
-    let(:params) do
-      {
-        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
-        settings: {
-          'monitor-timeout-ac': 30,
-          'monitor-timeout-dc': 10
-        }
-      }
-    end
+  #   let(:params) do
+  #     {
+  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
+  #       settings: {
+  #         'monitor-timeout-ac': 30,
+  #         'monitor-timeout-dc': 10
+  #       }
+  #     }
+  #   end
 
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('windows_power::scheme') }
+  #   it { is_expected.to compile.with_all_deps }
+  #   it { is_expected.to contain_class('windows_power::scheme') }
 
-    it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
-    it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
+  #   it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
+  #   it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
 
-    it { is_expected.not_to contain_exec('activate_existing_power_scheme').with_provider('windows') }
-    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
-    it { is_expected.not_to contain_exec('rename_power_scheme') }
-  end
+  #   it { is_expected.not_to contain_exec('activate_existing_power_scheme').with_provider('windows') }
+  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
+  # end
 end

--- a/spec/classes/scheme_spec.rb
+++ b/spec/classes/scheme_spec.rb
@@ -218,33 +218,31 @@ describe 'windows_power::scheme' do
     end
   end
 
-  # You cannot copy an non-existing scheme!
-  #
-  # context 'duplicate non-existing power scheme' do
-  #   let(:facts) do
-  #     super().merge(
-  #       {
-  #         power_schemes: {
-  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-  #         }
-  #       }
-  #     )
-  #   end
+  context 'duplicate non-existing power scheme' do
+    let(:facts) do
+      super().merge(
+        {
+          power_schemes: {
+            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+          }
+        }
+      )
+    end
 
-  #   let(:params) do
-  #     {
-  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
-  #       template: '7c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-  #     }
-  #   end
+    let(:params) do
+      {
+        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
+        template: '7c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+      }
+    end
 
-  #   it { is_expected.to compile.with_all_deps }
-  #   it { is_expected.to contain_class('windows_power::scheme') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('windows_power::scheme') }
 
-  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
 
-  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
-  # end
+    it { is_expected.not_to contain_exec('rename_power_scheme') }
+  end
 
   context 'configure existing power scheme' do
     context 'which is active already' do
@@ -320,37 +318,35 @@ describe 'windows_power::scheme' do
     end
   end
 
-  # You cannot copy an non-existing scheme!
-  #
-  # context 'configure non-existing power scheme' do
-  #   let(:facts) do
-  #     super().merge(
-  #       {
-  #         power_schemes: {
-  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-  #         }
-  #       }
-  #     )
-  #   end
+  context 'configure non-existing power scheme' do
+    let(:facts) do
+      super().merge(
+        {
+          power_schemes: {
+            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+          }
+        }
+      )
+    end
 
-  #   let(:params) do
-  #     {
-  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
-  #       settings: {
-  #         'monitor-timeout-ac': 30,
-  #         'monitor-timeout-dc': 10
-  #       }
-  #     }
-  #   end
+    let(:params) do
+      {
+        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c',
+        settings: {
+          'monitor-timeout-ac': 30,
+          'monitor-timeout-dc': 10
+        }
+      }
+    end
 
-  #   it { is_expected.to compile.with_all_deps }
-  #   it { is_expected.to contain_class('windows_power::scheme') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('windows_power::scheme') }
 
-  #   it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
-  #   it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
+    it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
+    it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
 
-  #   it { is_expected.not_to contain_exec('activate_existing_power_scheme').with_provider('windows') }
-  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
-  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
-  # end
+    it { is_expected.not_to contain_exec('activate_existing_power_scheme').with_provider('windows') }
+    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+    it { is_expected.not_to contain_exec('rename_power_scheme') }
+  end
 end

--- a/spec/classes/scheme_spec.rb
+++ b/spec/classes/scheme_spec.rb
@@ -36,7 +36,7 @@ describe 'windows_power::scheme' do
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('windows_power::scheme') }
 
-      it { is_expected.to contain_exec('activate_power_scheme').with_provider('windows') }
+      it { is_expected.to contain_exec('activate_existing_power_scheme').with_provider('windows') }
 
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }

--- a/spec/classes/scheme_spec.rb
+++ b/spec/classes/scheme_spec.rb
@@ -71,31 +71,31 @@ describe 'windows_power::scheme' do
     end
   end
 
-  # context 'activate non-existing power scheme' do
-  #   let(:facts) do
-  #     super().merge(
-  #       {
-  #         power_schemes: {
-  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-  #         }
-  #       }
-  #     )
-  #   end
+  context 'activate non-existing power scheme' do
+    let(:facts) do
+      super().merge(
+        {
+          power_schemes: {
+            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+          }
+        }
+      )
+    end
 
-  #   let(:params) do
-  #     {
-  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-  #     }
-  #   end
+    let(:params) do
+      {
+        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+      }
+    end
 
-  #   it { is_expected.to compile.with_all_deps }
-  #   it { is_expected.to contain_class('windows_power::scheme') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('windows_power::scheme') }
 
-  #   it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
+    it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
 
-  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
-  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
-  # end
+    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+    it { is_expected.not_to contain_exec('rename_power_scheme') }
+  end
 
   context 'rename existing power scheme' do
     context 'to new name' do

--- a/spec/classes/scheme_spec.rb
+++ b/spec/classes/scheme_spec.rb
@@ -64,38 +64,38 @@ describe 'windows_power::scheme' do
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('windows_power::scheme') }
 
-      it { is_expected.not_to contain_exec('activate_power_scheme') }
+      it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
 
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }
     end
   end
 
-  context 'activate non-existing power scheme' do
-    let(:facts) do
-      super().merge(
-        {
-          power_schemes: {
-            '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
-          }
-        }
-      )
-    end
+  # context 'activate non-existing power scheme' do
+  #   let(:facts) do
+  #     super().merge(
+  #       {
+  #         power_schemes: {
+  #           '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {}
+  #         }
+  #       }
+  #     )
+  #   end
 
-    let(:params) do
-      {
-        guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-      }
-    end
+  #   let(:params) do
+  #     {
+  #       guid: '3c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+  #     }
+  #   end
 
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('windows_power::scheme') }
+  #   it { is_expected.to compile.with_all_deps }
+  #   it { is_expected.to contain_class('windows_power::scheme') }
 
-    it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
+  #   it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
 
-    it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
-    it { is_expected.not_to contain_exec('rename_power_scheme') }
-  end
+  #   it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
+  #   it { is_expected.not_to contain_exec('rename_power_scheme') }
+  # end
 
   context 'rename existing power scheme' do
     context 'to new name' do
@@ -124,7 +124,7 @@ describe 'windows_power::scheme' do
 
       it { is_expected.to contain_exec('rename_power_scheme') }
 
-      it { is_expected.not_to contain_exec('activate_power_scheme') }
+      it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
     end
 
@@ -154,7 +154,7 @@ describe 'windows_power::scheme' do
 
       it { is_expected.not_to contain_exec('rename_power_scheme') }
 
-      it { is_expected.not_to contain_exec('activate_power_scheme') }
+      it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
     end
   end
@@ -183,11 +183,11 @@ describe 'windows_power::scheme' do
 
       it { is_expected.to contain_exec('duplicate_existing_power_scheme') }
 
-      it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
+      it { is_expected.to contain_exec('activate_duplicated_power_scheme').with_provider('windows') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }
     end
 
-    context 'as existing scheme' do
+    context 'as existing scheme do nothing' do
       let(:facts) do
         super().merge(
           {
@@ -213,7 +213,7 @@ describe 'windows_power::scheme' do
 
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
 
-      it { is_expected.not_to contain_exec('activate_power_scheme') }
+      it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }
     end
   end
@@ -241,7 +241,6 @@ describe 'windows_power::scheme' do
 
     it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
 
-    it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
     it { is_expected.not_to contain_exec('rename_power_scheme') }
   end
 
@@ -254,6 +253,10 @@ describe 'windows_power::scheme' do
               '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {
                 active: true
               }
+            },
+            power_settings: {
+              'monitor-timeout-ac': 0,
+              'monitor-timeout-dc': 0
             }
           }
         )
@@ -275,7 +278,7 @@ describe 'windows_power::scheme' do
       it { is_expected.to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
       it { is_expected.to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
 
-      it { is_expected.not_to contain_exec('activate_power_scheme') }
+      it { is_expected.not_to contain_exec('activate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }
     end
@@ -288,7 +291,7 @@ describe 'windows_power::scheme' do
               '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c': {
                 active: false
               }
-            }
+            },
           }
         )
       end
@@ -309,7 +312,7 @@ describe 'windows_power::scheme' do
       it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
       it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
 
-      it { is_expected.to contain_exec('activate_power_scheme').with_provider('windows') }
+      it { is_expected.to contain_exec('activate_existing_power_scheme').with_provider('windows') }
       it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
       it { is_expected.not_to contain_exec('rename_power_scheme') }
     end
@@ -342,7 +345,7 @@ describe 'windows_power::scheme' do
     it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-ac') }
     it { is_expected.not_to contain_exec('set_power_scheme_setting_monitor-timeout-dc') }
 
-    it { is_expected.to contain_exec('activate_power_scheme').with_provider('powershell') }
+    it { is_expected.not_to contain_exec('activate_existing_power_scheme').with_provider('windows') }
     it { is_expected.not_to contain_exec('duplicate_existing_power_scheme') }
     it { is_expected.not_to contain_exec('rename_power_scheme') }
   end


### PR DESCRIPTION
#### Pull Request (PR) description

1. Adds a new fact "hibernation_enabled" to tell if hibernation is on or off.
2. Adds a new fact "power_settings" which displays the settings for the currently active power scheme in seconds. Example:
```json
{
    "disk-timeout-ac": 0,
    "disk-timeout-dc": 0,
    "monitor-timeout-ac": 300,
    "monitor-timeout-dc": 0,
    "standby-timeout-ac": 300,
    "standby-timeout-dc": 0,
    "hibernate-timeout-ac": 0,
    "hibernate-timeout-dc": 0
}
```
3. hibernate.pp: only run when needed (no more corrective change on every run)
4. scheme.pp: activating and reaming a (duplicated) power scheme can now be done in one puppet run
5. scheme.pp: settings now check against the fact "power_settings" to avoid corrective changes

#### This Pull Request (PR) fixes the following issues
Fixes #57
